### PR TITLE
chore!(charts): rename `extraResources` into `extraObjects`

### DIFF
--- a/charts/cdviz-collector/templates/extra-manifests.yaml
+++ b/charts/cdviz-collector/templates/extra-manifests.yaml
@@ -1,0 +1,9 @@
+{{- range $_, $manifest := .Values.extraObjects }}
+---
+{{- if typeIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else if ne $manifest.enabled false }}
+{{- $def := unset $manifest "enabled" }}
+{{ tpl (toYaml $def) $ }}
+{{- end }}
+{{- end }}

--- a/charts/cdviz-collector/templates/extra-resources.yaml
+++ b/charts/cdviz-collector/templates/extra-resources.yaml
@@ -1,7 +1,0 @@
-{{- range $_, $extraResource := .Values.extraResources }}
-{{- if $extraResource.enabled }}
-{{- $def := unset $extraResource "enabled" }}
----
-{{- tpl (toYaml $def) $ }}
-{{- end}}
-{{- end }}

--- a/charts/cdviz-collector/values.yaml
+++ b/charts/cdviz-collector/values.yaml
@@ -143,9 +143,21 @@ env:
   #       key: GITHUB_WEBHOOK_SIGNATURE_TOKEN
 
 # Additional kubernetes resources to create. Helm template could be used.
-# you could use it to create secrets, or custom resources like external secrets,
-# configmaps, gateways, volumes, keda, ...
+# you could use it to create secrets, external secrets,
+# configmaps, gateways (http-route, filter, ...), volumes, keda, ...
 # - the name/key of the resource is used just to access the definition more easily than an arrays's index
 # - the 'enabled' field is used to enable/disable the resource (removed when the resource is templated)
-# - user can add any other resource definition as child node of extraResources
-extraResources: {}
+# - user can add any other resource definition as child node of extraObjects
+# The manifests can be defined as a string or as a dictionary. But the string doesn't use the 'enabled' field.
+extraObjects: {}
+  # extrernalSecrets:
+  #   enabled: true
+  #   apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: cdviz-collector-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: api-token
+  #         name: api-token

--- a/charts/cdviz-db/templates/extra-manifests.yaml
+++ b/charts/cdviz-db/templates/extra-manifests.yaml
@@ -1,0 +1,9 @@
+{{- range $_, $manifest := .Values.extraObjects }}
+---
+{{- if typeIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else if ne $manifest.enabled false }}
+{{- $def := unset $manifest "enabled" }}
+{{ tpl (toYaml $def) $ }}
+{{- end }}
+{{- end }}

--- a/charts/cdviz-db/templates/extra-resources.yaml
+++ b/charts/cdviz-db/templates/extra-resources.yaml
@@ -1,7 +1,0 @@
-{{- range $_, $extraResource := .Values.extraResources }}
-{{- if $extraResource.enabled }}
-{{- $def := unset $extraResource "enabled" }}
----
-{{- tpl (toYaml $def) $ }}
-{{- end}}
-{{- end }}

--- a/charts/cdviz-db/values.yaml
+++ b/charts/cdviz-db/values.yaml
@@ -18,12 +18,13 @@ env:
         key: DATABASE_URL
 
 # Additional kubernetes resources to create. Helm template could be used.
-# you could use it to create secrets, or custom resources like external secrets,
-# configmaps, gateways, volumes, keda, ...
+# you could use it to create secrets, external secrets,
+# configmaps, gateways (http-route, filter, ...), volumes, keda, ...
 # - the name/key of the resource is used just to access the definition more easily than an arrays's index
 # - the 'enabled' field is used to enable/disable the resource (removed when the resource is templated)
-# - user can add any other resource definition as child node of extraResources
-extraResources:
+# - user can add any other resource definition as child node of extraObjects
+# The manifests can be defined as a string or as a dictionary. But the string doesn't use the 'enabled' field.
+extraObjects:
   cloudnative-pg-basic:
     enabled: false
     apiVersion: postgresql.cnpg.io/v1
@@ -50,5 +51,5 @@ extraResources:
       name: cdviz-db-owner-secret
     type: kubernetes.io/basic-auth
     data:
-      username: '{{ "cdviz-su" b64enc }}'
+      username: '{{ "cdviz-su" | b64enc }}'
       password: '{{ "mysecretpassword" | b64enc }}'

--- a/charts/cdviz-grafana/templates/extra-manifests.yaml
+++ b/charts/cdviz-grafana/templates/extra-manifests.yaml
@@ -1,0 +1,9 @@
+{{- range $_, $manifest := .Values.extraObjects }}
+---
+{{- if typeIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else if ne $manifest.enabled false }}
+{{- $def := unset $manifest "enabled" }}
+{{ tpl (toYaml $def) $ }}
+{{- end }}
+{{- end }}

--- a/charts/cdviz-grafana/templates/extra-resources.yaml
+++ b/charts/cdviz-grafana/templates/extra-resources.yaml
@@ -1,7 +1,0 @@
-{{- range $_, $extraResource := .Values.extraResources }}
-{{- if $extraResource.enabled }}
-{{- $def := unset $extraResource "enabled" }}
----
-{{- tpl (toYaml $def) $ }}
-{{- end}}
-{{- end }}

--- a/charts/cdviz-grafana/values.yaml
+++ b/charts/cdviz-grafana/values.yaml
@@ -26,14 +26,21 @@ dashboards:
     grafana_dashboard: "1"
 
 # Additional kubernetes resources to create. Helm template could be used.
-# you could use it to create secrets, or custom resources like external secrets,
-# configmaps, gateways, volumes, keda, ...
+# you could use it to create secrets, external secrets,
+# configmaps, gateways (http-route, filter, ...), volumes, keda, ...
 # - the name/key of the resource is used just to access the definition more easily than an arrays's index
 # - the 'enabled' field is used to enable/disable the resource (removed when the resource is templated)
-# - user can add any other resource definition as child node of extraResources
-extraResources: {}
-  # sample:
-  #   enabled: false
-  #   apiVersion: v1
-  #   kind: Secret
-  #   ...
+# - user can add any other resource definition as child node of extraObjects
+# The manifests can be defined as a string or as a dictionary. But the string doesn't use the 'enabled' field.
+extraObjects: {}
+  # extrernalSecrets:
+  #   enabled: true
+  #   apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: cdviz-collector-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: api-token
+  #         name: api-token


### PR DESCRIPTION
- to follow the naming convention used into some other charts (grafana, traefik, nautobot, ...)