### PR TITLE
build(cdviz-db): fix "turn on the containerd image store"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
           - demos
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - uses: docker/setup-buildx-action@v3
       - name: check changed files
         uses: tj-actions/changed-files@v45
         id: changed-files

--- a/cdviz-db/.mise.toml
+++ b/cdviz-db/.mise.toml
@@ -5,7 +5,7 @@ PG_LOCAL_URL = "postgres://{{env.PG_LOCAL_USER}}:{{env.PG_LOCAL_PWD}}@127.0.0.1:
 
 [tools]
 # docker = "latest"
-atlas = "0.32.0"
+atlas = "0.35.0"
 
 [tasks."plan"]
 description = "update the migrations to reflect target `src/schema.sql`"

--- a/cdviz-db/.mise.toml
+++ b/cdviz-db/.mise.toml
@@ -69,7 +69,10 @@ run = "docker image ls --tree --filter 'reference=*/*/cdviz-db*'"
 
 [tasks."debug:bake"]
 description = "show the 'resovled' bake definition"
-run = ["docker buildx bake --print"]
+run = [
+  "docker info -f '{{ .DriverStatus }}'",
+  "docker buildx bake --print",
+]
 
 [tasks."build:cdviz-db-pg"]
 description = "build the docker image for the postgresql + extension (tag is based on posgresql version)"

--- a/cdviz-db/Dockerfile
+++ b/cdviz-db/Dockerfile
@@ -5,7 +5,7 @@ ARG PG_MAJOR=${PG_VERSION%%.*}
 #---------------------------------------------------------------------------------------------------
 # checkov:skip=CKV_DOCKER_7:Ensure the base image uses a non latest version tag
 # trivy:ignore:AVD-DS-0001
-FROM --platform=$BUILDPLATFORM arigaio/atlas:0.34.0-community-alpine AS cdviz-db-migration
+FROM --platform=$BUILDPLATFORM arigaio/atlas:0.35.0-community-alpine AS cdviz-db-migration
 LABEL org.opencontainers.image.source="https://github.com/cdviz-dev/cdviz"
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 


### PR DESCRIPTION
```
ERROR: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```