### PR TITLE
fix(updatecli): replace dasel/v2 engine with file-based regex targets

### DIFF
--- a/updatecli/updatecli.d/cdviz-collector.yaml
+++ b/updatecli/updatecli.d/cdviz-collector.yaml
@@ -38,13 +38,13 @@ sources:
 targets:
   valuesTag:
     name: "charts/cdviz-collector/values.yaml image.tag"
-    kind: yaml
+    kind: file
     sourceid: collectorVersion
     scmid: default
     spec:
       file: charts/cdviz-collector/values.yaml
-      key: $.image.tag
-      engine: dasel/v2
+      matchpattern: '  tag: [0-9]+\.[0-9]+\.[0-9]+'
+      replacepattern: '  tag: {{ source "collectorVersion" }}'
 
   # FIXME: useless to update the version of the app in the chart as is it override by the "prepare-publish script" used for chart, So first update the script
   # chartAppVersion:

--- a/updatecli/updatecli.d/cdviz-db.yaml
+++ b/updatecli/updatecli.d/cdviz-db.yaml
@@ -31,13 +31,13 @@ sources:
 targets:
   chartImageTag:
     name: "charts/cdviz-db/values.yaml image.tag"
-    kind: yaml
+    kind: file
     sourceid: dbMigrationVersion
     scmid: default
     spec:
       file: charts/cdviz-db/values.yaml
-      key: $.image.tag
-      engine: dasel/v2
+      matchpattern: '  tag: [0-9]+\.[0-9]+\.[0-9]+'
+      replacepattern: '  tag: {{ source "dbMigrationVersion" }}'
 
 actions:
   dbMigrationVersion:

--- a/updatecli/updatecli.d/helm-deps.yaml
+++ b/updatecli/updatecli.d/helm-deps.yaml
@@ -27,13 +27,13 @@ sources:
 targets:
   kubewatchVersion:
     name: "charts/cdviz-collector/Chart.yaml kubewatch dependency version"
-    kind: yaml
+    kind: file
     sourceid: kubewatch
     scmid: default
     spec:
       file: charts/cdviz-collector/Chart.yaml
-      key: "$.dependencies[0].version"
-      engine: dasel/v2
+      matchpattern: '    version: [0-9]+\.[0-9]+\.[0-9]+'
+      replacepattern: '    version: {{ source "kubewatch" }}'
 
 actions:
   kubewatch:

--- a/updatecli/updatecli.d/mise-tools.yaml
+++ b/updatecli/updatecli.d/mise-tools.yaml
@@ -177,153 +177,153 @@ sources:
 targets:
   helmCharts:
     name: "charts/mise.toml helm version"
-    kind: toml
+    kind: file
     sourceid: helm
     scmid: default
     spec:
       file: charts/mise.toml
-      key: tools.helm
-      engine: dasel/v2
+      matchpattern: 'helm = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'helm = "{{ source "helm" }}"'
 
   kubectlCollectorChart:
     name: "charts/cdviz-collector/mise.toml kubectl version"
-    kind: toml
+    kind: file
     sourceid: kubectl
     scmid: default
     spec:
       file: charts/cdviz-collector/mise.toml
-      key: tools.kubectl
-      engine: dasel/v2
+      matchpattern: 'kubectl = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'kubectl = "{{ source "kubectl" }}"'
 
   kindCollectorChart:
     name: "charts/cdviz-collector/mise.toml kind version"
-    kind: toml
+    kind: file
     sourceid: kind
     scmid: default
     spec:
       file: charts/cdviz-collector/mise.toml
-      key: tools.kind
-      engine: dasel/v2
+      matchpattern: 'kind = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'kind = "{{ source "kind" }}"'
 
   kubectlStackK8s:
     name: "demos/stack-k8s/mise.toml kubectl version"
-    kind: toml
+    kind: file
     sourceid: kubectl
     scmid: default
     spec:
       file: demos/stack-k8s/mise.toml
-      key: tools.kubectl
-      engine: dasel/v2
+      matchpattern: 'kubectl = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'kubectl = "{{ source "kubectl" }}"'
 
   kindStackK8s:
     name: "demos/stack-k8s/mise.toml kind version"
-    kind: toml
+    kind: file
     sourceid: kind
     scmid: default
     spec:
       file: demos/stack-k8s/mise.toml
-      key: tools.kind
-      engine: dasel/v2
+      matchpattern: 'kind = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'kind = "{{ source "kind" }}"'
 
   ctlptlStackK8s:
     name: "demos/stack-k8s/mise.toml ctlptl version"
-    kind: toml
+    kind: file
     sourceid: ctlptl
     scmid: default
     spec:
       file: demos/stack-k8s/mise.toml
-      key: tools.ctlptl
-      engine: dasel/v2
+      matchpattern: 'ctlptl = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'ctlptl = "{{ source "ctlptl" }}"'
 
   yqRoot:
     name: "mise.toml yq version"
-    kind: toml
+    kind: file
     sourceid: yq
     scmid: default
     spec:
       file: mise.toml
-      key: tools.yq
-      engine: dasel/v2
+      matchpattern: 'yq = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'yq = "{{ source "yq" }}"'
 
   yqGrafana:
     name: "cdviz-grafana/mise.toml yq version"
-    kind: toml
+    kind: file
     sourceid: yq
     scmid: default
     spec:
       file: cdviz-grafana/mise.toml
-      key: tools.yq
-      engine: dasel/v2
+      matchpattern: '"yq" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"yq" = "{{ source "yq" }}"'
 
   gitcliffRoot:
     name: "mise.toml git-cliff version"
-    kind: toml
+    kind: file
     sourceid: gitcliff
     scmid: default
     spec:
       file: mise.toml
-      key: tools.git-cliff
-      engine: dasel/v2
+      matchpattern: 'git-cliff = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: 'git-cliff = "{{ source "gitcliff" }}"'
 
   bunDb:
     name: "cdviz-db/mise.toml bun version"
-    kind: toml
+    kind: file
     sourceid: bun
     scmid: default
     spec:
       file: cdviz-db/mise.toml
-      key: tools.bun
-      engine: dasel/v2
+      matchpattern: '"bun" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"bun" = "{{ source "bun" }}"'
 
   bunSite:
     name: "cdviz-site/mise.toml bun version"
-    kind: toml
+    kind: file
     sourceid: bun
     scmid: default
     spec:
       file: cdviz-site/mise.toml
-      key: tools.bun
-      engine: dasel/v2
+      matchpattern: '"bun" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"bun" = "{{ source "bun" }}"'
 
   bunDashboards:
     name: "cdviz-grafana/dashboards_generator/mise.toml bun version"
-    kind: toml
+    kind: file
     sourceid: bun
     scmid: default
     spec:
       file: cdviz-grafana/dashboards_generator/mise.toml
-      key: tools.bun
-      engine: dasel/v2
+      matchpattern: '"bun" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"bun" = "{{ source "bun" }}"'
 
   dprintAdr:
     name: "adr/mise.toml dprint version"
-    kind: toml
+    kind: file
     sourceid: dprint
     scmid: default
     spec:
       file: adr/mise.toml
-      key: tools.dprint
-      engine: dasel/v2
+      matchpattern: '"dprint" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"dprint" = "{{ source "dprint" }}"'
 
   dprintSite:
     name: "cdviz-site/mise.toml dprint version"
-    kind: toml
+    kind: file
     sourceid: dprint
     scmid: default
     spec:
       file: cdviz-site/mise.toml
-      key: tools.dprint
-      engine: dasel/v2
+      matchpattern: '"dprint" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"dprint" = "{{ source "dprint" }}"'
 
   biomeDashboards:
     name: "cdviz-grafana/dashboards_generator/mise.toml biome version"
-    kind: toml
+    kind: file
     sourceid: biome
     scmid: default
     spec:
       file: cdviz-grafana/dashboards_generator/mise.toml
-      key: tools.biome
-      engine: dasel/v2
+      matchpattern: '"biome" = "[0-9]+\.[0-9]+\.[0-9]+"'
+      replacepattern: '"biome" = "{{ source "biome" }}"'
 
   golangmigrateDb:
     name: "cdviz-db/mise.toml golang-migrate version"


### PR DESCRIPTION
dasel/v2 is unsupported for kind:yaml and kind:toml in the current
  updatecli version, causing pipeline failures. The toml engine also
  reformats entire files, breaking indentation and key quoting.

  Switch all affected targets to kind:file with matchpattern/replacepattern,
  which does in-place regex substitution without touching surrounding content.