### PR TITLE
fix(Dockerfile): fix multiplatform build for cdviz-db

### DIFF
--- a/cdviz-db/Dockerfile
+++ b/cdviz-db/Dockerfile
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------------------------------
 # checkov:skip=CKV_DOCKER_7:Ensure the base image uses a non latest version tag
 # trivy:ignore:AVD-DS-0001
-FROM --platform=$BUILDPLATFORM migrate/migrate:4 AS cdviz-db-migration
+FROM migrate/migrate:4 AS cdviz-db-migration
 LABEL org.opencontainers.image.source="https://github.com/cdviz-dev/cdviz"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 


### PR DESCRIPTION
### Description
Issue: the arm64 image could not use maybe the download binary path have error while parse environment variable to it.

### Checklist

- [x] I have read and agreed to the [Contributor License Agreement (CLA)](https://cla-assistant.io/cdviz-dev/cdviz).
- [x] My code follows the project's coding standards.
- [x] I have signed off my commits (`git commit -s`).
